### PR TITLE
Allow populating branches that are not explicitly specified in YAML

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,17 +1,17 @@
 db_pgconn: dbname=packages
 zmq_change: ipc:///tmp/p-vector-changes
 path: /mirror/debs
+populate: true
 origin: AOSC
+ttl: 14
 label: AOSC OS
 codename: Fsck
 ---
 branch: stable
 desc: AOSC OS Repository - Stable
-ttl: 14
 ---
 branch: stable-proposed
 desc: AOSC OS Repository - Stable (Proposed/Candidate Updates)
-ttl: 14
 ---
 branch: testing
 desc: AOSC OS Repository - Testing

--- a/p-vector
+++ b/p-vector
@@ -14,6 +14,7 @@ import module_ipc
 import module_scan
 import module_sync
 import module_release
+import module_config
 
 logging.basicConfig(
     format='%(asctime)s %(levelname).1s [%(name)5.5s] %(message)s',
@@ -42,6 +43,8 @@ def main():
             if i is None:
                 continue
             conf_branches[i['branch']] = i
+
+    module_config.normalize(conf_common, conf_branches)
 
     db = psycopg2.connect(conf_common['db_pgconn'],
                           cursor_factory=psycopg2.extras.DictCursor)

--- a/p-vector
+++ b/p-vector
@@ -35,7 +35,7 @@ def main():
     action_args = sys.argv[3:]
 
     with open(conf_file, 'rb') as f:
-        y = yaml.load_all(f)
+        y = yaml.safe_load_all(f)
         global conf_common, conf_branches
         conf_common = next(y)
         for i in y:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,6 +4,7 @@ install(FILES
         internal_db.py
         internal_dpkg_version.py
         internal_pkgscan.py
+        module_config.py
         module_ipc.py
         module_release.py
         module_scan.py

--- a/python/module_config.py
+++ b/python/module_config.py
@@ -2,9 +2,15 @@ import logging
 import sys
 from pathlib import PosixPath
 
+from typing import Mapping, Any
+
 logger_conf = logging.getLogger('CONF')
 
-def normalize_branch(conf_common: dict, conf_branch: dict):
+PVConf = Mapping[str, Any]
+BranchesConf = Mapping[str, Mapping[str, Any]]
+
+
+def normalize_branch(conf_common: PVConf, conf_branch: PVConf) -> None:
     """ Populate missing config values in branch from default values
         String substitution is allowed within string typed keys, namely suite and desc:
             %BRANCH% will be replaced with the branch name
@@ -22,7 +28,7 @@ def normalize_branch(conf_common: dict, conf_branch: dict):
             conf_branch[key] = conf_common[key]
 
 
-def populate_branches(conf_common: dict, conf_branches: dict):
+def populate_branches(conf_common: PVConf, conf_branches: BranchesConf) -> None:
     """ Automatically create branches with directories on disk """
     pool_dir = conf_common['path'] + '/pool'
     for i in PosixPath(pool_dir).iterdir():
@@ -32,12 +38,11 @@ def populate_branches(conf_common: dict, conf_branches: dict):
         if branch_name in conf_branches.keys():
             # Do not touch ones already in YAML
             continue
-        else:
-            conf_branches[branch_name] = {"branch": branch_name}
+        conf_branches[branch_name] = {"branch": branch_name}
 
 
-def normalize(conf_common: dict, conf_branches: dict):
-    if "populate" in conf_common.keys() and conf_common["populate"]:
+def normalize(conf_common: PVConf, conf_branches: BranchesConf) -> None:
+    if conf_common.get("populate", False):
         populate_branches(conf_common, conf_branches)
     for conf_branch in conf_branches.values():
         normalize_branch(conf_common, conf_branch)

--- a/python/module_config.py
+++ b/python/module_config.py
@@ -1,0 +1,43 @@
+import logging
+import sys
+from pathlib import PosixPath
+
+logger_conf = logging.getLogger('CONF')
+
+def normalize_branch(conf_common: dict, conf_branch: dict):
+    """ Populate missing config values in branch from default values
+        String substitution is allowed within string typed keys, namely suite and desc:
+            %BRANCH% will be replaced with the branch name
+    """
+    for key in ["ttl", "desc", "suite"]:
+        if key in conf_branch.keys():
+            continue
+        if key not in conf_common.keys():
+            logger_conf.fatal(
+                "Missing %s for branch %s which has no global default", key, conf_branch["branch"])
+            sys.exit(1)
+        if key != "ttl":
+            conf_branch[key] = conf_common[key].replace("%BRANCH%", conf_branch["branch"])
+        else:
+            conf_branch[key] = conf_common[key]
+
+
+def populate_branches(conf_common: dict, conf_branches: dict):
+    """ Automatically create branches with directories on disk """
+    pool_dir = conf_common['path'] + '/pool'
+    for i in PosixPath(pool_dir).iterdir():
+        if not i.is_dir():
+            continue
+        branch_name = i.name
+        if branch_name in conf_branches.keys():
+            # Do not touch ones already in YAML
+            continue
+        else:
+            conf_branches[branch_name] = {"branch": branch_name}
+
+
+def normalize(conf_common: dict, conf_branches: dict):
+    if "populate" in conf_common.keys() and conf_common["populate"]:
+        populate_branches(conf_common, conf_branches)
+    for conf_branch in conf_branches.values():
+        normalize_branch(conf_common, conf_branch)

--- a/python/module_scan.py
+++ b/python/module_scan.py
@@ -257,7 +257,11 @@ def scan(db, base_dir: str, branch_list: list):
         if not i.is_dir():
             continue
         branch_name = i.name
-        branch_idx = branch_list.index(branch_name)
+        try:
+            branch_idx = branch_list.index(branch_name)
+        except ValueError as e:
+            logger_scan.warn('Skipping %s as it is not specified in configuration', branch_name)
+            continue
         logger_scan.info('Branch: %s', branch_name)
         for j in PosixPath(pool_dir).joinpath(branch_name).iterdir():
             if not j.is_dir():

--- a/python/module_scan.py
+++ b/python/module_scan.py
@@ -259,8 +259,9 @@ def scan(db, base_dir: str, branch_list: list):
         branch_name = i.name
         try:
             branch_idx = branch_list.index(branch_name)
+            branch_list.remove(branch_name)
         except ValueError as e:
-            logger_scan.warn('Skipping %s as it is not specified in configuration', branch_name)
+            logger_scan.warning('Skipping %s as it is not specified in configuration', branch_name)
             continue
         logger_scan.info('Branch: %s', branch_name)
         for j in PosixPath(pool_dir).joinpath(branch_name).iterdir():
@@ -272,6 +273,8 @@ def scan(db, base_dir: str, branch_list: list):
                 scan_dir(db, base_dir, branch_name, component_name, branch_idx)
             finally:
                 db.commit()
+    if len(branch_list) > 0:
+        logger_scan.warning("Branches skipped as they are missing on disk: %s", " ".join(branch_list))
     refresh = (table_mtime(db) > lastmtime)
     internal_db.init_index(db, refresh)
     #db.execute('ANALYZE')

--- a/python/module_scan.py
+++ b/python/module_scan.py
@@ -273,7 +273,7 @@ def scan(db, base_dir: str, branch_list: list):
                 scan_dir(db, base_dir, branch_name, component_name, branch_idx)
             finally:
                 db.commit()
-    if len(branch_list) > 0:
+    if branch_list:
         logger_scan.warning("Branches skipped as they are missing on disk: %s", " ".join(branch_list))
     refresh = (table_mtime(db) > lastmtime)
     internal_db.init_index(db, refresh)


### PR DESCRIPTION
Regarding topic-based maintenance upcoming in a few weeks, p-vector is currently unable to handle addition and removal of branches (or soon-to-be, topics) without manual edit of YAML. This is quite undesirable and we don't want people to mess with repo configurations too much.

This PR allows p-vector to automatically consider each directory under `pool` to be a branch even when the directory is not explicitly specifed in YAML. This feature is controlled by a common option `populate` and will be active whenever the flag is set to true.